### PR TITLE
feat: bump to go 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devbytes-cloud/freight
 
-go 1.24.2
+go 1.26.5
 
 require (
 	github.com/pterm/pterm v0.12.83


### PR DESCRIPTION
Simply pulls in a newer go. Not the latest, because it came out yesterday but we can pull that in a few days.